### PR TITLE
Add original option to RulesEngine::Outcome

### DIFF
--- a/lib/rules_engine/condition.rb
+++ b/lib/rules_engine/condition.rb
@@ -1,5 +1,10 @@
 class RulesEngine::Condition
-  attr_accessor :name, :condition, :when_true, :when_false, :original, :override
+  attr_accessor :name,
+                :condition,
+                :when_true,
+                :when_false,
+                :original,
+                :override
 
   def initialize(options = {})
     @name = options.fetch(:name)

--- a/lib/rules_engine/outcome.rb
+++ b/lib/rules_engine/outcome.rb
@@ -1,9 +1,13 @@
 class RulesEngine::Outcome
-  attr_accessor :name, :values, :reference
+  attr_accessor :name,
+                :values,
+                :reference,
+                :original
 
   def initialize(options = {})
     @name = options.fetch(:name)
     @values = options.fetch(:values)
     @reference = options.fetch(:reference, nil)
+    @original = options.fetch(:original, nil)
   end
 end

--- a/spec/rules_engine/condition_spec.rb
+++ b/spec/rules_engine/condition_spec.rb
@@ -1,24 +1,114 @@
 require 'spec_helper'
 
-describe 'Condition' do
-  let(:true_action) { RulesEngine::Outcome.new(name: 'name', values: [{ reference: 'true action', parameter: '1' }]) }
-  let(:false_action) { RulesEngine::Outcome.new(name: 'name', values: [{ reference: 'false action', parameter: '1' }]) }
+describe RulesEngine::Condition do
+  describe '.new' do
+    subject { described_class.new(options) }
 
-  context 'Constructing a new instance from a hash' do
-
-    let(:condition) { RulesEngine::Condition.new(name: 'name', condition: '2 > 1', when_true: true_action, when_false: false_action) }
-
-    specify { expect(condition.name).to eq('name') }
-    specify { expect(condition.condition).to eq('2 > 1') }
-    specify { expect(condition.when_true).to eq(true_action) }
-    specify { expect(condition.when_false).to eq(false_action) }
-
-    context 'Missing required arguments' do
-      context 'name' do
-        specify { expect { RulesEngine::Condition.new(condition: '2 > 1', when_true: true_action, when_false: false_action) }.to raise_error }
+    context 'where only required arguments are provided' do
+      let(:options) do
+        {
+          name: 'a condition',
+          condition: '2 > 1',
+        }
       end
-      context 'condition' do
-        specify { expect { RulesEngine::Condition.new(name: 'name', when_true: true_action, when_false: false_action) }.to raise_error }
+
+      it 'sets name' do
+        expect(subject.name).to eq('a condition')
+      end
+
+      it 'sets condition' do
+        expect(subject.condition).to eq('2 > 1')
+      end
+
+      it 'does not set when_true' do
+        expect(subject.when_true).to be_nil
+      end
+
+      it 'does not set when_false' do
+        expect(subject.when_false).to be_nil
+      end
+
+      it 'does not set original' do
+        expect(subject.original).to be_nil
+      end
+
+      it 'does not set override' do
+        expect(subject.override).to be_nil
+      end
+    end
+
+    context 'where all available arguments are provided' do
+      let(:options) do
+        {
+          name: 'a condition',
+          condition: '2 > 1',
+          when_true: true_action,
+          when_false: false_action,
+          original: 'original condition',
+          override: true,
+        }
+      end
+
+      let(:true_action) do
+        RulesEngine::Outcome.new(
+          name: 'an outcome',
+          values: [{ reference: 'true action', parameter: '1' }],
+        )
+      end
+
+      let(:false_action) do
+        RulesEngine::Outcome.new(
+          name: 'another outcome',
+          values: [{ reference: 'false action', parameter: '1' }],
+        )
+      end
+
+      it 'sets name' do
+        expect(subject.name).to eq('a condition')
+      end
+
+      it 'sets condition' do
+        expect(subject.condition).to eq('2 > 1')
+      end
+
+      it 'sets when_true' do
+        expect(subject.when_true).to eq(true_action)
+      end
+
+      it 'sets when_false' do
+        expect(subject.when_false).to eq(false_action)
+      end
+
+      it 'sets original' do
+        expect(subject.original).to eq('original condition')
+      end
+
+      it 'sets override' do
+        expect(subject.override).to eq(true)
+      end
+    end
+
+    context 'where name argument is missing' do
+      let(:options) do
+        {
+          condition: '2 > 1',
+        }
+      end
+
+      specify do
+        expect { subject }.to raise_error(KeyError)
+      end
+    end
+
+    context 'where condition argument is missing' do
+      let(:options) do
+        {
+          name: 'a condition',
+        }
+      end
+
+      specify do
+        expect { subject }.to raise_error(KeyError)
       end
     end
   end

--- a/spec/rules_engine/outcome_spec.rb
+++ b/spec/rules_engine/outcome_spec.rb
@@ -1,27 +1,83 @@
 require 'spec_helper'
 
-describe 'Outcome' do
+describe RulesEngine::Outcome do
+  describe '.new' do
+    subject { described_class.new(options) }
 
-  context 'Constructing a new instance from a hash' do
+    context 'where only required arguments are provided' do
+      let(:options) do
+        {
+          name: 'an outcome',
+          values: [{ parameter: 'some parameter', reference: 'some reference' }],
+        }
+      end
 
-    let(:outcome) do
-      RulesEngine::Outcome.new(name: 'some outcome',
-        reference: 'outcome_reference',
-        values: [{ parameter: 'some parameter', reference: 'some reference' }])
+      it 'sets name' do
+        expect(subject.name).to eq('an outcome')
+      end
+
+      it 'sets values' do
+        expect(subject.values).to eq([{ parameter: 'some parameter', reference: 'some reference' }])
+      end
+
+      it 'does not set reference' do
+        expect(subject.reference).to be_nil
+      end
+
+      it 'does not set original' do
+        expect(subject.original).to be_nil
+      end
     end
 
-    specify { expect(outcome.name).to eq('some outcome') }
-    specify { expect(outcome.reference).to eq('outcome_reference') }
-    specify { expect(outcome.values.first[:parameter]).to eq('some parameter') }
-    specify { expect(outcome.values.first[:reference]).to eq('some reference') }
-  end
+    context 'where all available arguments are provided' do
+      let(:options) do
+        {
+          name: 'an outcome',
+          values: [{ parameter: 'some parameter', reference: 'some reference' }],
+          reference: 'outcome_reference',
+          original: 'original outcome',
+        }
+      end
 
-  context 'Missing required arguments' do
-    context 'name' do
-      specify { expect { RulesEngine::Outcome.new(values: [{ parameter: 'some parameter', reference: 'some reference' }]) }.to raise_error }
+      it 'sets name' do
+        expect(subject.name).to eq('an outcome')
+      end
+
+      it 'sets values' do
+        expect(subject.values).to eq([{ parameter: 'some parameter', reference: 'some reference' }])
+      end
+
+      it 'sets reference' do
+        expect(subject.reference).to eq('outcome_reference')
+      end
+
+      it 'sets original' do
+        expect(subject.original).to eq('original outcome')
+      end
     end
-    context 'values' do
-      specify { expect { RulesEngine::Outcome.new(name: 'some outcome') }.to raise_error }
+
+    context 'where name argument is missing' do
+      let(:options) do
+        {
+          values: [{ parameter: 'some parameter', reference: 'some reference' }],
+        }
+      end
+
+      specify do
+        expect { subject }.to raise_error(KeyError)
+      end
+    end
+
+    context 'where values argument is missing' do
+      let(:options) do
+        {
+          name: 'an outcome',
+        }
+      end
+
+      specify do
+        expect { subject }.to raise_error(KeyError)
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow us to access the original outcome in the same way as with condition.