### PR TITLE
Add original option to RulesEngine::Set

### DIFF
--- a/lib/rules_engine/set.rb
+++ b/lib/rules_engine/set.rb
@@ -1,8 +1,11 @@
 class RulesEngine::Set
-  attr_reader :root, :name
+  attr_reader :name,
+              :root,
+              :original
 
   def initialize(options = {})
     @root = options.fetch(:root)
     @name = options.fetch(:name)
+    @original = options.fetch(:original, nil)
   end
 end

--- a/spec/rules_engine/set_spec.rb
+++ b/spec/rules_engine/set_spec.rb
@@ -1,21 +1,81 @@
 require 'spec_helper'
 
-describe 'Set' do
-  let(:condition) { RulesEngine::Condition.new(name: 'name', condition: '2 > 1') }
-  context 'Constructing a new instance from a hash' do
+describe RulesEngine::Set do
+  describe '.new' do
+    subject { described_class.new(options) }
 
-    let(:ruleset) { RulesEngine::Set.new(name: 'some set', root: condition) }
-
-    specify { expect(ruleset.name).to eq('some set') }
-    specify { expect(ruleset.root).to eq(condition) }
-  end
-
-  context 'Missing required arguments' do
-    context 'name' do
-      specify { expect { RulesEngine::Set.new(root: condition) }.to raise_error }
+    let(:root_condition) do
+      RulesEngine::Condition.new(
+        name: 'a condition',
+        condition: '2 > 1',
+      )
     end
-    context 'root' do
-      specify { expect { RulesEngine::Set.new(name: 'some set') }.to raise_error }
+
+    context 'where only required arguments are provided' do
+      let(:options) do
+        {
+          name: 'a rule set',
+          root: root_condition,
+        }
+      end
+
+      it 'sets name' do
+        expect(subject.name).to eq('a rule set')
+      end
+
+      it 'sets root' do
+        expect(subject.root).to eq(root_condition)
+      end
+
+      it 'does not set original' do
+        expect(subject.original).to be_nil
+      end
+    end
+
+    context 'where all available arguments are provided' do
+      let(:options) do
+        {
+          name: 'a rule set',
+          root: root_condition,
+          original: 'original rule set',
+        }
+      end
+
+      it 'sets name' do
+        expect(subject.name).to eq('a rule set')
+      end
+
+      it 'sets root' do
+        expect(subject.root).to eq(root_condition)
+      end
+
+      it 'sets original' do
+        expect(subject.original).to eq('original rule set')
+      end
+    end
+
+    context 'where name argument is missing' do
+      let(:options) do
+        {
+          root: root_condition,
+        }
+      end
+
+      specify do
+        expect { subject }.to raise_error(KeyError)
+      end
+    end
+
+    context 'where root argument is missing' do
+      let(:options) do
+        {
+          name: 'a rule set',
+        }
+      end
+
+      specify do
+        expect { subject }.to raise_error(KeyError)
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow us to access the original rule set in the same way as with condition and outcome.